### PR TITLE
fix(server): make max_tokens configurable instead of hardcoded 50

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,1 +1,2 @@
 OPENAI_API_KEY=your_openai_api_key
+SUSTAIN_MAX_TOKENS=100

--- a/server/routes/sustain.js
+++ b/server/routes/sustain.js
@@ -47,6 +47,14 @@ fs.readFile(phrasesFilePath, 'utf8', (err, data) => {
 const ENERGY_PER_TOKEN = 0.000002; // kWh per token
 const CO2_PER_KWH = 0.4; // kg CO₂ per kWh
 
+// Cap on response length, configurable via environment.
+// 50 was too tight and truncated replies mid-sentence (SUSTAIN#24).
+const DEFAULT_MAX_RESPONSE_TOKENS = 100;
+const parsedMaxTokens = Number.parseInt(process.env.SUSTAIN_MAX_TOKENS, 10);
+const MAX_RESPONSE_TOKENS = Number.isInteger(parsedMaxTokens) && parsedMaxTokens > 0
+  ? parsedMaxTokens
+  : DEFAULT_MAX_RESPONSE_TOKENS;
+
 // Store accumulated token savings
 let totalTokensSaved = 0;
 
@@ -219,7 +227,7 @@ router.post('/', async (req, res) => {
         "3. Do NOT claim to automate anything. You ONLY summarize and optimize text."
       },
       { role: "user", content: optimizedInput + " in <20 words." }],
-      max_tokens: 50,
+      max_tokens: MAX_RESPONSE_TOKENS,
     });
 
     const sustainOutputText = sustainResponse.choices[0].message.content.trim();

--- a/server/routes/sustain.js
+++ b/server/routes/sustain.js
@@ -50,7 +50,7 @@ const CO2_PER_KWH = 0.4; // kg CO₂ per kWh
 // Cap on response length, configurable via environment.
 // 50 was too tight and truncated replies mid-sentence (SUSTAIN#24).
 const DEFAULT_MAX_RESPONSE_TOKENS = 100;
-const parsedMaxTokens = Number.parseInt(process.env.SUSTAIN_MAX_TOKENS, 10);
+const parsedMaxTokens = Number(process.env.SUSTAIN_MAX_TOKENS);
 const MAX_RESPONSE_TOKENS = Number.isInteger(parsedMaxTokens) && parsedMaxTokens > 0
   ? parsedMaxTokens
   : DEFAULT_MAX_RESPONSE_TOKENS;


### PR DESCRIPTION
## Summary
Responses from the `/sustain` route were truncated mid-sentence because `max_tokens` was hardcoded to 50 in the OpenAI call. This change:

- Caps responses at a configurable `MAX_RESPONSE_TOKENS`, read from the `SUSTAIN_MAX_TOKENS` environment variable
- Defaults to 100 (enough headroom for the "<20 words" prompt without runaway output)
- Validates the env value (positive integer) and falls back to the default otherwise
- Documents the new variable in `server/.env.example`

Fixes djleamen/SUSTAIN#24 (web app side).

## Testing
- `node --check server/routes/sustain.js` passes
- Verified the constant resolution logic for unset/invalid/valid env values

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxkyJimQmCvkjbfQ9dz9zR)_