### PR TITLE
fix(server): return JSON and guard missing OpenAI key

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -42,6 +42,25 @@ app.use((req, res, next) => {
 
 app.use('/api/sustain', sustainRoutes);
 
+app.use((err, req, res, next) => {
+  /**
+   * Error-handling middleware that returns JSON instead of an HTML stack
+   * trace for malformed or oversized request bodies.
+   * 
+   * @param {Error} err - Error thrown by upstream middleware (e.g. body parser).
+   * @param {Object} req - Express request object.
+   * @param {Object} res - Express response object.
+   * @param {Function} next - Next middleware function.
+   */
+  if (err.type === 'entity.parse.failed') {
+    return res.status(400).json({ error: "Invalid JSON in request body" });
+  }
+  if (err.type === 'entity.too.large') {
+    return res.status(413).json({ error: "Request body too large" });
+  }
+  next(err);
+});
+
 app.listen(PORT, () => {
   /**
    * Starts the Express server and listens on the specified port.

--- a/server/routes/sustain.js
+++ b/server/routes/sustain.js
@@ -18,9 +18,15 @@ const router = express.Router();
 const OpenAI = require('openai');
 require('dotenv').config();
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+// Initialize OpenAI client only if a key is configured, so the server can
+// still start and serve non-OpenAI routes without one.
+const openai = process.env.OPENAI_API_KEY
+  ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+  : null;
+
+if (!openai) {
+  console.warn("OPENAI_API_KEY is not set; chat completions will be unavailable.");
+}
 
 // Load phrases to remove from file
 const phrasesFilePath = path.join(__dirname, '../phrases_to_remove.txt');
@@ -215,6 +221,14 @@ router.post('/', async (req, res) => {
 
     // Determine energy consumption per token for the selected model
     const energyPerToken = MODEL_ENERGY_CONSUMPTION[selectedModel] || MODEL_ENERGY_CONSUMPTION['gpt-3.5-turbo'];
+
+    // Fail gracefully if the OpenAI client is not configured
+    if (!openai) {
+      return res.status(503).json({
+        error: "OpenAI API is not configured on this server",
+        percentageSaved: 0
+      });
+    }
 
     // Send only optimized input to OpenAI
     const sustainResponse = await openai.chat.completions.create({


### PR DESCRIPTION
## Summary

Ports two robustness fixes from the hardened `SUSTAINAzureDeploy` backend, which the `SUSTAINWebApp` server was missing.

### 1. Return JSON instead of an HTML stack trace for bad request bodies
`server/app.js` had no error-handling middleware, so a malformed JSON body (or one over the 10 MB limit) bubbled up as an unhandled Express error and emitted an HTML stack trace to the client. Added the same `entity.parse.failed` / `entity.too.large` handler used in the AzureDeploy variant, returning a clean JSON `400`/`413`.

### 2. Guard the OpenAI client against a missing API key
`server/routes/sustain.js` constructed `new OpenAI(...)` unconditionally. With no `OPENAI_API_KEY` set, requests failed inside the try/catch and returned a generic `500`. The client is now created only when the key is present, logs a warning at startup if it isn't, and the route responds with a clear `503` ("OpenAI API is not configured") instead.

## Why
Both are small, defensive error-handling improvements that bring `SUSTAINWebApp` in line with its already-hardened deploy sibling. No behavior change on the happy path.

## Testing
- `server/routes/sustain.js` and `server/app.js` mirror the corresponding files in `SUSTAINAzureDeploy`, which already run this code in production.
- Logic is unchanged for valid requests; new branches only trigger on malformed input or missing configuration.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNSSo3EVcHGq54H9hiVoSj)_