### PR TITLE
fix(sustain): guard math optimizer against division by zero

### DIFF
--- a/server/routes/sustain.js
+++ b/server/routes/sustain.js
@@ -139,6 +139,11 @@ const isMathOptimization = (input) => {
         result = num1 * num2;
         break;
       case '/':
+        // Division by zero would yield Infinity and be reported as a valid
+        // "Math detected!" result; treat it as a normal prompt instead.
+        if (num2 === 0) {
+          return null;
+        }
         result = num1 / num2;
         break;
       default:


### PR DESCRIPTION
## What

The `/sustain` route has a fast-path that intercepts simple arithmetic
(`isMathOptimization`) and answers without calling OpenAI. The `/` case
divided `num1 / num2` with no zero check, so an input like `5/0`:

- matched the math regex,
- computed `Infinity` (not `null`),
- and was returned to the client as `"Math detected! Result: Infinity"` with
  `percentageSaved: 100`.

## Fix

Return `null` from the `'/'` case when the divisor is `0`, so the input falls
through to the normal optimization + OpenAI path — the same way any other
non-math input is handled. No other behavior changes.

## Testing

Traced by hand: `"5/0"` now returns `null` from `isMathOptimization` and is
processed as a normal prompt; `"6/2"` still returns `3`. This is a pure
control-flow guard with no new dependencies.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JHX5RDsKZP48Wrp9iex8J)_