### PR TITLE
fix(server): rate-limit the OpenAI-backed /api/sustain endpoint

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -16,6 +16,10 @@ const sustainRoutes = require('./routes/sustain');
 const app = express();
 const PORT = process.env.PORT || 8080;
 
+// Trust the first proxy hop (Azure's load balancer) so req.ip reflects the
+// real client address for rate limiting rather than the proxy's address.
+app.set('trust proxy', 1);
+
 // Configure CORS to allow requests from frontend
 const corsOptions = { 
   origin: ['https://sustainai.ca', 'http://localhost:3000'], // localhost for development
@@ -40,7 +44,57 @@ app.use((req, res, next) => {
   next();
 });
 
-app.use('/api/sustain', sustainRoutes);
+// Simple in-memory fixed-window rate limiter. The /api/sustain route calls the
+// paid OpenAI API on every request with no auth, so throttling per client IP
+// keeps an anonymous caller from driving unbounded API spend / quota
+// exhaustion. In-memory state matches the rest of the server (single instance);
+// back it with a shared store if the app is ever scaled horizontally.
+const RATE_LIMIT_WINDOW_MS = Number(process.env.RATE_LIMIT_WINDOW_MS) || 60_000;
+const RATE_LIMIT_MAX = Number(process.env.RATE_LIMIT_MAX) || 30;
+const rateLimitHits = new Map();
+
+// Periodically drop expired entries so the tracking map cannot grow unbounded.
+// Unref'd so it never keeps the process alive on its own (e.g. during tests).
+const rateLimitSweep = setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of rateLimitHits) {
+    if (now > entry.resetAt) {
+      rateLimitHits.delete(key);
+    }
+  }
+}, RATE_LIMIT_WINDOW_MS);
+if (typeof rateLimitSweep.unref === 'function') {
+  rateLimitSweep.unref();
+}
+
+const rateLimiter = (req, res, next) => {
+  /**
+   * Fixed-window per-IP rate limiter for the OpenAI-backed route.
+   * 
+   * @param {Object} req - Express request object.
+   * @param {Object} res - Express response object.
+   * @param {Function} next - Next middleware function.
+   */
+  const now = Date.now();
+  const key = req.ip || 'unknown';
+  const entry = rateLimitHits.get(key);
+
+  if (!entry || now > entry.resetAt) {
+    rateLimitHits.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return next();
+  }
+
+  if (entry.count >= RATE_LIMIT_MAX) {
+    const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+    res.setHeader('Retry-After', String(retryAfter));
+    return res.status(429).json({ error: "Too many requests, please slow down", percentageSaved: 0 });
+  }
+
+  entry.count += 1;
+  next();
+};
+
+app.use('/api/sustain', rateLimiter, sustainRoutes);
 
 app.use((err, req, res, next) => {
   /**


### PR DESCRIPTION
## Problem

`POST /api/sustain` calls the paid OpenAI API (`openai.chat.completions.create`) on every request. There is **no authentication and no rate limiting** anywhere in `server/app.js` or the route, so an anonymous caller can hammer the endpoint and drive unbounded OpenAI spend / quota exhaustion — a cost-denial-of-service. The route already validates and caps the input itself (string check, `substring(0, 1000)`, model allowlist); the missing piece is a throttle.

## Fix

- Add a small **in-memory fixed-window rate limiter** (per client IP) mounted in front of `/api/sustain`. Returns `429` with a `Retry-After` header when a client exceeds the cap.
- **No new dependencies** — the in-memory approach matches the server's existing single-instance state (e.g. the accumulated `totalTokensSaved` counter). A shared store would be the right move only if the app is scaled horizontally, which it currently isn't.
- Limits are configurable via `RATE_LIMIT_WINDOW_MS` (default 60s) and `RATE_LIMIT_MAX` (default 30 requests/window).
- An `unref()`'d interval sweeps expired entries so the tracking map can't grow unbounded.
- `app.set('trust proxy', 1)` so `req.ip` reflects the real client behind Azure App Service's load balancer rather than the proxy address.

## Notes

- Self-contained change to `server/app.js` only; no route logic changed.
- Chose an in-house limiter over `express-rate-limit` deliberately: `express` itself isn't even a direct dependency in `package.json`, so pulling in a new runtime package risked a deploy that doesn't install it. Zero new deps avoids that entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8hL4gquqrhs1ZqNSJsmSt

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8hL4gquqrhs1ZqNSJsmSt)_