### PR TITLE
fix(api): use same-origin API base URL instead of dead hardcoded host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Base URL for the SUSTAIN backend API.
+#
+# Leave this unset in production: the React build and the Express server are
+# deployed together as a single Azure Web App, so API requests are same-origin
+# and use relative paths (an empty base URL).
+#
+# For local development, point this at the backend server so the CRA dev server
+# (http://localhost:3000) can reach it, e.g.:
+#   REACT_APP_API_BASE_URL=http://localhost:8080
+REACT_APP_API_BASE_URL=

--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,11 @@ const App = () => {
   const [loadingCo2, setLoadingCo2] = useState(false);
   const [model, setModel] = useState('gpt-3.5-turbo'); // should update model default here... is 3.5-turbo still available?
   const [isMobile, setIsMobile] = useState(false);
-  const API_BASE_URL = 'https://sustain-backend.azurewebsites.net'; // deprecated: this endpoint does not exist anymore
+  // The React build and the Express API deploy together as a single Azure Web
+  // App, so the API is same-origin in production (an empty base yields relative
+  // paths). Override with REACT_APP_API_BASE_URL for local development, e.g.
+  // http://localhost:8080 when running the CRA dev server against the backend.
+  const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || '';
 
   const mathOptimizer = new MathOptimizer(); 
 


### PR DESCRIPTION
## Problem
`src/App.js` hardcoded the API base as `https://sustain-backend.azurewebsites.net`, and the author's own inline comment already flagged that endpoint as no longer existing:

```js
const API_BASE_URL = 'https://sustain-backend.azurewebsites.net'; // deprecated: this endpoint does not exist anymore
```

This constant backs every network call — `handleSendMessage` POSTs to `${API_BASE_URL}/api/sustain`, `fetchCo2Savings` GETs `${API_BASE_URL}/api/sustain/co2-savings`, and it's passed into `SettingsModal` as `apiBaseUrl` — so all chat and CO₂ requests were hitting a dead host and failing.

## Fix
The React build and the Express server (`server/app.js`, serving `/api/sustain`) are deployed together as a single Azure Web App, so the API is same-origin in production. This change:

- Defaults `API_BASE_URL` to an empty string, so requests use relative, same-origin paths in production.
- Reads `process.env.REACT_APP_API_BASE_URL` first, so local development can point at the backend (e.g. `http://localhost:8080`, which the server already allow-lists in CORS) without code changes.
- Adds a `.env.example` documenting the variable. (`.env*` files are already gitignored.)

## Notes
- No behavior change in production beyond requests now reaching the live host instead of the dead one.
- Out of scope but noticed nearby: the `model` default still carries an unresolved `// should update model default here...` TODO comment in `src/App.js`; left untouched to keep this PR focused.

## Testing
- Change is a single constant plus a new example file; no logic paths altered. `npm run build` compiles the constant unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Nm6kPFkSRdFCmXU9sBvrd)_