### PR TITLE
fix(logger): guard localStorage reads and cap stored log history

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -14,12 +14,18 @@ const readStoredLogs = () => {
   /**
    * Safely reads the persisted log array from localStorage.
    * Returns an empty array if nothing is stored or the value is corrupt.
+   * Enforces the MAX_LOGS cap on read as well, so a legacy/oversized store
+   * (written by an older version or manually tampered) can't return an
+   * unbounded array to callers.
    *
    * @returns {Array} An array of log messages.
    */
   try {
     const stored = JSON.parse(localStorage.getItem('appLogs'));
-    return Array.isArray(stored) ? stored : [];
+    if (!Array.isArray(stored)) {
+      return [];
+    }
+    return stored.length > MAX_LOGS ? stored.slice(-MAX_LOGS) : stored;
   } catch {
     // Corrupt/non-JSON value in storage - start fresh rather than throwing.
     return [];

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -6,10 +6,30 @@
  * Last Modified: Jan 2026
  */
 
+// Maximum number of log entries kept in localStorage, so the store can't grow
+// unbounded and eventually throw when it hits the quota.
+const MAX_LOGS = 500;
+
+const readStoredLogs = () => {
+  /**
+   * Safely reads the persisted log array from localStorage.
+   * Returns an empty array if nothing is stored or the value is corrupt.
+   *
+   * @returns {Array} An array of log messages.
+   */
+  try {
+    const stored = JSON.parse(localStorage.getItem('appLogs'));
+    return Array.isArray(stored) ? stored : [];
+  } catch {
+    // Corrupt/non-JSON value in storage - start fresh rather than throwing.
+    return [];
+  }
+};
+
 const log = (message, level = 'INFO') => {
   /**
    * Logs a message with a timestamp and level.
-   * 
+   *
    * @param {string} message - The message to log.
    * @param {string} level - The log level (e.g., INFO, ERROR).
    */
@@ -18,9 +38,16 @@ const log = (message, level = 'INFO') => {
   console.log(logMessage);
 
   // Store logs in localStorage for persistence
-  const logs = JSON.parse(localStorage.getItem('appLogs')) || [];
+  const logs = readStoredLogs();
   logs.push(logMessage);
-  localStorage.setItem('appLogs', JSON.stringify(logs));
+  if (logs.length > MAX_LOGS) {
+    logs.splice(0, logs.length - MAX_LOGS);
+  }
+  try {
+    localStorage.setItem('appLogs', JSON.stringify(logs));
+  } catch {
+    // Storage unavailable or quota exceeded - logging must never break callers.
+  }
 };
 
 // Log an error message
@@ -39,10 +66,10 @@ const logError = (error) => {
 const getLogs = () => {
   /**
    * Retrieves all stored log messages.
-   * 
+   *
    * @returns {Array} An array of log messages.
    */
-  return JSON.parse(localStorage.getItem('appLogs')) || [];
+  return readStoredLogs();
 };
 
 module.exports = { log, logError, getLogs };


### PR DESCRIPTION
## What changed

`src/utils/logger.js` read persisted logs with a bare `JSON.parse(localStorage.getItem('appLogs'))` in two places (`log()` and `getLogs()`). If the `appLogs` value in localStorage is ever corrupt or non-JSON, `JSON.parse` throws — and because `log()` runs on core paths (every message send, dark-mode load, CO₂ fetch), a single bad value would break those flows.

- Added a `readStoredLogs()` helper that wraps `JSON.parse` in `try/catch` and validates the parsed value is an array, returning `[]` otherwise.
- Both read sites now use it.
- Capped the stored array at `MAX_LOGS` (500) entries so it can't grow unbounded and eventually throw on `setItem`.
- Wrapped the `setItem` write in `try/catch` so a full/unavailable localStorage can't break callers either.

## Why

Defensive robustness: logging should never throw and take down the feature that was being logged. Prevents both the corrupt-value crash and the unbounded-growth quota crash.

## Testing

- `node --check src/utils/logger.js` — syntax OK.
- Functional test with a mocked `localStorage`: corrupt (`"{not json"`) and non-array (`"42"`) values both recover to `[]` instead of throwing; writing 600 entries caps storage at exactly 500.

## Scope

Single-file change; public API (`log`, `logError`, `getLogs`) unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYuUvWVRhGCC5ECYGwb32i)_