### PR TITLE
fix: settings modal crash, CO₂ unit label, and math error handling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -85,16 +85,21 @@ const App = () => {
     // Check if the input is a math expression and solve it locally
     if (mathOptimizer.recognizeMath(userInput)) {
       const result = mathOptimizer.solveMath(userInput);
-      setMessages(prevMessages => [
-        ...prevMessages,
-        { sender: 'SUSTAIN', text: `Math detected! Result: ${result}`, percentageSaved: 100 }
-      ]);
-  
-      // Update Token Savings
-      setTotalPercentageSaved(prevTotal => prevTotal + 100);
-      setMessageCount(prevCount => prevCount + 1);
-  
-      return;
+      // Only short-circuit when we actually computed a number; solveMath
+      // returns an "Error: ..." string for unparseable input, which should
+      // fall through to the normal API path instead of being shown as a result.
+      if (typeof result === 'number' && Number.isFinite(result)) {
+        setMessages(prevMessages => [
+          ...prevMessages,
+          { sender: 'SUSTAIN', text: `Math detected! Result: ${result}`, percentageSaved: 100 }
+        ]);
+
+        // Update Token Savings
+        setTotalPercentageSaved(prevTotal => prevTotal + 100);
+        setMessageCount(prevCount => prevCount + 1);
+
+        return;
+      }
     }
   
     try {

--- a/src/App.js
+++ b/src/App.js
@@ -71,19 +71,6 @@ const App = () => {
     };
   }, []);
 
-  const toggleDarkMode = () => {
-    /**
-     * Toggles dark mode state and saves preference to local storage.
-     * 
-     * @param {Function} setDarkMode - Function to set dark mode state.
-     */
-    setDarkMode(prevMode => {
-      const newMode = !prevMode;
-      localStorage.setItem("darkMode", newMode);
-      return newMode;
-    });
-  };
-
   const handleSendMessage = async (userInput) => {
     /**
      * Handles sending user messages to the SUSTAIN API and updating chat state.
@@ -245,7 +232,7 @@ const App = () => {
         <SettingsModal
           onClose={() => setShowSettings(false)}
           darkMode={darkMode}
-          toggleDarkMode={toggleDarkMode}
+          setDarkMode={setDarkMode}
           fetchCo2Savings={fetchCo2Savings}
           co2Savings={co2Savings}
           loadingCo2={loadingCo2}

--- a/src/App.js
+++ b/src/App.js
@@ -30,8 +30,6 @@ const App = () => {
   const [showInfo, setShowInfo] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [darkMode, setDarkMode] = useState(false);
-  const [co2Savings, setCo2Savings] = useState(null);
-  const [loadingCo2, setLoadingCo2] = useState(false);
   const [model, setModel] = useState('gpt-3.5-turbo'); // should update model default here... is 3.5-turbo still available?
   const [isMobile, setIsMobile] = useState(false);
   // The React build and the Express API deploy together as a single Azure Web
@@ -162,24 +160,6 @@ const App = () => {
     }
   };
 
-  // Fetch CO₂ Savings
-  const fetchCo2Savings = async () => {
-    setLoadingCo2(true);
-    try {
-      const response = await fetch(`${API_BASE_URL}/api/sustain/co2-savings`);
-      if (!response.ok) throw new Error(`HTTP error! Status: ${response.status}`);
-
-      const data = await response.json();
-      setCo2Savings(data);
-      log(`CO₂ savings fetched: ${JSON.stringify(data)}`);
-    } catch (error) {
-      logError(error);
-      console.error("Failed to fetch CO₂ savings:", error);
-    } finally {
-      setLoadingCo2(false);
-    }
-  };
-
   const handleModelChange = (newModel) => {
     /**
      * Handles changes to the selected AI model.
@@ -229,7 +209,7 @@ const App = () => {
       {/* Chat Area & Input */}
       <ChatArea messages={messages} />
       <InputArea className={darkMode ? 'dark-mode' : 'light-mode'} onSendMessage={handleSendMessage} />
-      <TokenSavings averageSavings={averageSavings} co2Savings={co2Savings} />
+      <TokenSavings averageSavings={averageSavings} />
 
       {/* Modals */}
       {showInfo && <InfoModal onClose={() => setShowInfo(false)} darkMode={darkMode} />}
@@ -238,9 +218,6 @@ const App = () => {
           onClose={() => setShowSettings(false)}
           darkMode={darkMode}
           setDarkMode={setDarkMode}
-          fetchCo2Savings={fetchCo2Savings}
-          co2Savings={co2Savings}
-          loadingCo2={loadingCo2}
           apiBaseUrl={API_BASE_URL}
           model={model}
           setModel={handleModelChange}

--- a/src/components/SettingsModal.js
+++ b/src/components/SettingsModal.js
@@ -122,7 +122,7 @@ const SettingsModal = ({ onClose, darkMode, setDarkMode, apiBaseUrl, model, setM
             <br />
             🌱 {co2Savings.totalKwhSaved} kWh of power
             <br />
-            🌍 {co2Savings.totalCo2Saved} metric tons of CO₂ emissions
+            🌍 {co2Savings.totalCo2Saved} kg of CO₂ emissions
           </p>
         )}
       </div>

--- a/src/utils/MathOptimizer.test.js
+++ b/src/utils/MathOptimizer.test.js
@@ -1,0 +1,31 @@
+/**
+ * Tests for MathOptimizer.solveMath
+ *
+ * These lock the return-type contract that App.js relies on: a valid
+ * expression yields a finite number, while an unparseable one yields an
+ * "Error: ..." string (which the caller must not present as a result).
+ */
+
+import MathOptimizer from './MathOptimizer';
+
+describe('MathOptimizer.solveMath', () => {
+  const optimizer = new MathOptimizer();
+
+  test('returns a finite number for a valid expression', () => {
+    expect(optimizer.solveMath('2 plus 2')).toBe(4);
+    expect(optimizer.solveMath('10 times 3')).toBe(30);
+  });
+
+  test('returns an "Error" string for an unparseable expression', () => {
+    const result = optimizer.solveMath('apples plus oranges');
+    expect(typeof result).toBe('string');
+    expect(result.startsWith('Error')).toBe(true);
+  });
+
+  test('recognizeMath flags word-operator-word input that solveMath cannot evaluate', () => {
+    // This is the case that previously surfaced an "Error: ..." string to the
+    // user as a "Math detected!" result with 100% savings.
+    expect(optimizer.recognizeMath('apples plus oranges')).toBe(true);
+    expect(typeof optimizer.solveMath('apples plus oranges')).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary

Three small, self-contained fixes found during a code-quality sweep of the web app.

### 1. `fix(settings)`: Settings modal crashed on open
`SettingsModal` reads and calls a **required** `setDarkMode` prop — its mount `useEffect` calls `setDarkMode(savedDarkMode)` and its internal `toggleDarkMode` calls `setDarkMode(!darkMode)`. But `App.js` passed `toggleDarkMode={toggleDarkMode}` and never passed `setDarkMode`, so `setDarkMode` was `undefined` and **opening the Settings modal threw `TypeError: setDarkMode is not a function`** every time. Now passes `setDarkMode`; the now-unused App-level `toggleDarkMode` helper is removed.

### 2. `fix(co2)`: CO₂ savings mislabeled as "metric tons"
The server computes `totalCo2Saved = energySaved * 0.4 kg/kWh`, i.e. the value is in **kilograms**, but the modal displayed it as `metric tons` — a 1000× unit error shown to users. Label corrected to `kg`.

### 3. `fix(chat)`: local math errors presented as successful results
`recognizeMath` matches word-operator-word input (e.g. `"apples plus oranges"`), and `solveMath` returns an `"Error: ..."` string for unparseable expressions. That string was rendered as `Math detected! Result: Error: ...` while crediting 100% token savings. The result path now short-circuits **only** when a finite number was computed; otherwise it falls through to the normal API path. Added `MathOptimizer.test.js` locking `solveMath`'s return-type contract.

## Testing
- `CI=true npm run build` → compiled successfully (warnings-as-errors clean).
- `react-scripts test src/utils/MathOptimizer.test.js` → 3 passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfqQPWkTooa6Hp62mnU518)_